### PR TITLE
Add dash button to keypad

### DIFF
--- a/lg-remote-control.js
+++ b/lg-remote-control.js
@@ -328,7 +328,7 @@ class LgRemoteControl extends LitElement {
                         <button class="btn-keypad ripple" @click=${() => this._button("7")}>7</button>
                         <button class="btn-keypad ripple" @click=${() => this._button("8")}>8</button>
                         <button class="btn-keypad ripple" @click=${() => this._button("9")}>9</button>
-                        <button class="btn-keypad"></button>
+                        <button class="btn-keypad ripple" @click=${() => this._button("DASH")}>—</button>
                         <button class="btn-keypad ripple" @click=${() => this._button("0")}>0</button>
                         <button class="btn-keypad"></button>
                   </div>


### PR DESCRIPTION
Adds a "dash" button to the keypad to enable the remote to select DTV sub-channels (See https://github.com/madmicio/LG-WebOS-Remote-Control/issues/30)

(`DASH` is one of the [button entities](https://www.home-assistant.io/integrations/webostv/#service-webostvbutton) associated with WebOS TV)

What the new button looks like when rendered:
![image](https://user-images.githubusercontent.com/10189269/143785094-9fb6c5b9-3a2a-40f8-a2fa-92776ae9f3b5.png)

