### PR TITLE
Support Dark Mode per default

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ colors:
 ```
 
 
-- buttons: set buttons  background color    - default: "#f2f0fa"
+- buttons: set buttons  background color    - default: "var(--secondary-background-color)"
 - texts: set buttons color                  - default: "var(--primary-text-color)"
 - background: set remote background color   - default: "var(--primary-background-color)"
 ```yaml

--- a/lg-remote-control.js
+++ b/lg-remote-control.js
@@ -254,7 +254,7 @@ class LgRemoteControl extends LitElement {
 
         const backgroundColor = this.config.colors && this.config.colors.background ? this.config.colors.background : "var(--primary-background-color)";
         const borderColor = this.config.colors && this.config.colors.border ? this.config.colors.border: "var(--app-header-text-color)";
-        const buttonColor = this.config.colors && this.config.colors.buttons ? this.config.colors.buttons : "#f2f0fa";
+        const buttonColor = this.config.colors && this.config.colors.buttons ? this.config.colors.buttons : "var(--secondary-background-color)";
         const textColor = this.config.colors && this.config.colors.texts ? this.config.colors.texts : "var(--primary-text-color)";
 
         return html`


### PR DESCRIPTION
(Sorry for reopening a new pull request, this is the same as #70. i fucked up the branches in my fork by force pushing on mistake)

At the moment the default button background color is hard-coded to #f2f0fa. This is a problem as it results in a ugly looking remote in the default dark mode:

![image](https://user-images.githubusercontent.com/6146026/146613727-ee11859e-7251-4315-89e1-b0d334f3eb2e.png)


By updating the default color to var(--secondary-background-color) the resulting remote looks good in both light and dark mode:

![image](https://user-images.githubusercontent.com/6146026/146613742-b34b8dee-701b-4298-9fe1-db953a8180ab.png)
![image](https://user-images.githubusercontent.com/6146026/146613748-3585d7fd-b4c2-465b-9c15-3ba4fca8fda8.png)
