### PR TITLE
Add ability to specify custom volume up/down/mute actions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,24 @@ channels:
     number: '503'
 ```
 
+### Sound device Options
+
+If you have an external device that outputs the sound and the volume up/down/mute buttons are not passed to this device (like when your RF LG remote is not pointed to your IR-controlled soundbar..) you can define another media player as sound output. You can also specify an entity that should be controlled when the TV is in the off state.
+
+| Name | Type | Default | Supported options | Description |
+| -------------- | ----------- | ------------ | ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `image` | url | **Required** | /local/your_dir/tv_logo/your_image.png | url of the image to be displayed in the channel pad popup |
+| `number` | string | **Required** | number | TV channel number |
+```yaml
+channels:
+  - image: /local/lg_remote/tv_logo/Rai 1 HD.png
+    number: '501'
+  - image: /local/lg_remote/tv_logo/Rai 2 HD.png
+    number: '502'
+  - image: /local/lg_remote/tv_logo/Rai 3 HD.png
+    number: '503'
+```
+
 ### Colors Options
 | Name | Type | Default | Supported options | Description |
 | -------------- | ----------- | ------------ | ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -126,16 +126,14 @@ If you have an external device that outputs the sound and the volume up/down/mut
 
 | Name | Type | Default | Supported options | Description |
 | -------------- | ----------- | ------------ | ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `image` | url | **Required** | /local/your_dir/tv_logo/your_image.png | url of the image to be displayed in the channel pad popup |
-| `number` | string | **Required** | number | TV channel number |
+| `name` | string | **Required** | Output options: tv_speaker, tv_external_speaker, tv_speaker_headphone, external_optical, external_arc, lineout, headphone, bt_soundbar and "none" for off-state | The name of the output mode this setting applies to |
+| `entity` | string | **Required** | number | Entity of the media_player that should be controlled |
 ```yaml
-channels:
-  - image: /local/lg_remote/tv_logo/Rai 1 HD.png
-    number: '501'
-  - image: /local/lg_remote/tv_logo/Rai 2 HD.png
-    number: '502'
-  - image: /local/lg_remote/tv_logo/Rai 3 HD.png
-    number: '503'
+sound_devices:
+  - name: none
+    entity: media_player.sonos_bar
+  - name: external_optical
+    entity: media_player.living_room_speaker
 ```
 
 ### Colors Options

--- a/lg-remote-control.js
+++ b/lg-remote-control.js
@@ -246,6 +246,8 @@ class LgRemoteControl extends LitElement {
 
     render() {
         const stateObj = this.hass.states[this.config.entity];
+        const audioStateObj = stateObj;
+
         const colorButtons = this.config.color_buttons === "enable";
 
         const borderWidth = this.config.dimensions && this.config.dimensions.border_width ? this.config.dimensions.border_width : "1px";
@@ -386,13 +388,13 @@ class LgRemoteControl extends LitElement {
 <!-- ################################# COLORED BUTTONS END ################################# -->
 
                   <div class="grid-container-volume-channel-control" >
-                      <button class="btn ripple"  style="border-radius: 50% 50% 0px 0px; margin: 0px auto 0px auto; height: 100%;" @click=${() => this._media_player_service("volume_up")}><ha-icon icon="mdi:plus"/></button>
+                      <button class="btn ripple"  style="border-radius: 50% 50% 0px 0px; margin: 0px auto 0px auto; height: 100%;" @click=${() => this._media_player_entity_service("volume_up", audioStateObj.entity_id)}><ha-icon icon="mdi:plus"/></button>
                       <button class="btn-flat flat-high ripple" style="margin-top: 0px; height: 50%;" @click=${() => this._button("HOME")}><ha-icon icon="mdi:home"></button>
                       <button class="btn ripple" style="border-radius: 50% 50% 0px 0px; margin: 0px auto 0px auto; height: 100%;" @click=${() => this._button("CHANNELUP")}><ha-icon icon="mdi:chevron-up"/></button>
                       <button class="btn" style="border-radius: 0px; cursor: default; margin: 0px auto 0px auto; height: 100%;"><ha-icon icon="${stateObj.attributes.is_volume_muted === true ? 'mdi:volume-off' : 'mdi:volume-high'}"/></button>
                       <button class="btn ripple" Style="color:${stateObj.attributes.is_volume_muted === true ? 'red' : ''}; height: 100%;"" @click=${() => this._button("MUTE")}><span class="${stateObj.attributes.is_volume_muted === true ? 'blink' : ''}"><ha-icon icon="mdi:volume-mute"></span></button>
                       <button class="btn" style="border-radius: 0px; cursor: default; margin: 0px auto 0px auto; height: 100%;"><ha-icon icon="mdi:parking"/></button>
-                      <button class="btn ripple" style="border-radius: 0px 0px 50% 50%;  margin: 0px auto 0px auto; height: 100%;" @click=${() => this._media_player_service("volume_down")}><ha-icon icon="mdi:minus"/></button>
+                      <button class="btn ripple" style="border-radius: 0px 0px 50% 50%;  margin: 0px auto 0px auto; height: 100%;" @click=${() => this._media_player_entity_service("volume_down", audioStateObj.entity_id)}><ha-icon icon="mdi:minus"/></button>
                       <button class="btn-flat flat-high ripple" style="margin-bottom: 0px; height: 50%;" @click=${() => this._button("INFO")}><ha-icon icon="mdi:information-variant"/></button>
                       <button class="btn ripple" style="border-radius: 0px 0px 50% 50%;  margin: 0px auto 0px auto; height: 100%;"  @click=${() => this._button("CHANNELDOWN")}><ha-icon icon="mdi:chevron-down"/></button>
                   </div>
@@ -448,10 +450,14 @@ class LgRemoteControl extends LitElement {
         });
     }
 
-    _media_player_service(service) {
+    _media_player_entity_service(service, entity){
         this.hass.callService("media_player", service, {
-            entity_id: this.config.entity,
+            entity_id: entity,
         });
+    }
+
+    _media_player_service(service) {
+        this._media_player_entity_service(service,this.config.entity)
     }
 
     _select_source(source) {
@@ -474,7 +480,6 @@ class LgRemoteControl extends LitElement {
             console.log("Invalid configuration");
         }
         this.config = config;
-        console.log(config)
     }
 
     getCardSize() {

--- a/lg-remote-control.js
+++ b/lg-remote-control.js
@@ -474,6 +474,7 @@ class LgRemoteControl extends LitElement {
             console.log("Invalid configuration");
         }
         this.config = config;
+        console.log(config)
     }
 
     getCardSize() {

--- a/lg-remote-control.js
+++ b/lg-remote-control.js
@@ -541,6 +541,7 @@ class LgRemoteControl extends LitElement {
         this.config = config;
         if("sound_devices" in this.config){
             this.config.sound_devices.forEach(el => { this._custom_sound_devices[el.name] = el})
+
             //this._custom_sound_devices = this.config.sound_devices;
         }
     }

--- a/lg-remote-control.js
+++ b/lg-remote-control.js
@@ -254,11 +254,12 @@ class LgRemoteControl extends LitElement {
 
         const stateObj = this.hass.states[this.config.entity];
         console.log(stateObj.attributes.sound_output, this._custom_sound_devices);
-
-        if(this._custom_sound_devices.includes(stateObj.attributes.sound_output)){
-
+        if(!stateObj.attributes.includes("sound_output")){
+            // tv is off
+            const audioStateObj = stateObj;
+        }
+        else if(this._custom_sound_devices.includes(stateObj.attributes.sound_output)){
             const audioStateObj = this._custom_sound_devices[stateObj.attributes.sound_output].entity;
-
         }else{
             const audioStateObj = stateObj;
         }
@@ -496,7 +497,7 @@ class LgRemoteControl extends LitElement {
         }
         this.config = config;
         if("custom_sound_devices" in this.config){
-            this._custom_sound_devices = this.config._custom_sound_devices;
+            this._custom_sound_devices = this.config.custom_sound_devices;
         }
     }
 

--- a/lg-remote-control.js
+++ b/lg-remote-control.js
@@ -251,6 +251,7 @@ class LgRemoteControl extends LitElement {
     }
 
     render() {
+
         const stateObj = this.hass.states[this.config.entity];
         console.log(stateObj.attributes.sound_output, this._custom_sound_devices)
 

--- a/lg-remote-control.js
+++ b/lg-remote-control.js
@@ -253,7 +253,7 @@ class LgRemoteControl extends LitElement {
     render() {
         const stateObj = this.hass.states[this.config.entity];
         console.log("HELLOOOO")
-        if(stateObj.attributes.sound_output in this._custom_sound_devices){
+        if(this._custom_sound_devices.includes(stateObj.attributes.sound_output)){
 
             const audioStateObj = this._custom_sound_devices[stateObj.attributes.sound_output].entity;
 

--- a/lg-remote-control.js
+++ b/lg-remote-control.js
@@ -541,7 +541,13 @@ class LgRemoteControl extends LitElement {
         }
         this.config = config;
         if("sound_devices" in this.config){
-            this.config.sound_devices.forEach(el => { this._custom_sound_devices[el.name] = el})
+            this.config.sound_devices.forEach(el => {
+                if(!el.entity){
+                    console.warn("Custom sound_device {} missing entity id!".format(el.name))
+                    return;
+                }
+                this._custom_sound_devices[el.name] = el
+            })
 
             //this._custom_sound_devices = this.config.sound_devices;
         }

--- a/lg-remote-control.js
+++ b/lg-remote-control.js
@@ -408,7 +408,7 @@ class LgRemoteControl extends LitElement {
                       <button class="btn-flat flat-high ripple" style="margin-top: 0px; height: 50%;" @click=${() => this._button("HOME")}><ha-icon icon="mdi:home"></button>
                       <button class="btn ripple" style="border-radius: 50% 50% 0px 0px; margin: 0px auto 0px auto; height: 100%;" @click=${() => this._button("CHANNELUP")}><ha-icon icon="mdi:chevron-up"/></button>
                       <button class="btn" style="border-radius: 0px; cursor: default; margin: 0px auto 0px auto; height: 100%;"><ha-icon icon="${stateObj.attributes.is_volume_muted === true ? 'mdi:volume-off' : 'mdi:volume-high'}"/></button>
-                      <button class="btn ripple" Style="color:${stateObj.attributes.is_volume_muted === true ? 'red' : ''}; height: 100%;"" @click=${() => this._button("MUTE")}><span class="${stateObj.attributes.is_volume_muted === true ? 'blink' : ''}"><ha-icon icon="mdi:volume-mute"></span></button>
+                      <button class="btn ripple" Style="color:${stateObj.attributes.is_volume_muted === true ? 'red' : ''}; height: 100%;"" @click=${() => this._mute_toggle() /*this._button("MUTE")*/}><span class="${stateObj.attributes.is_volume_muted === true ? 'blink' : ''}"><ha-icon icon="mdi:volume-mute"></span></button>
                       <button class="btn" style="border-radius: 0px; cursor: default; margin: 0px auto 0px auto; height: 100%;"><ha-icon icon="mdi:parking"/></button>
                       <button class="btn ripple" style="border-radius: 0px 0px 50% 50%;  margin: 0px auto 0px auto; height: 100%;" @click=${() => this._media_player_entity_service("volume_down", this._current_audio_device.entity_id)}><ha-icon icon="mdi:minus"/></button>
                       <button class="btn-flat flat-high ripple" style="margin-bottom: 0px; height: 50%;" @click=${() => this._button("INFO")}><ha-icon icon="mdi:information-variant"/></button>
@@ -450,6 +450,24 @@ class LgRemoteControl extends LitElement {
             }
         };
         this.ownerDocument.querySelector("home-assistant").dispatchEvent(popupEvent);
+    }
+
+    _mute_toggle(){
+        if(this._current_audio_device.attributes.is_volume_muted){
+            //is now muted
+            this.hass.callService("media_player", "volume_mute", {
+                entity_id: this._current_audio_device.entity_id,
+                is_volume_muted: false
+            });
+        }
+        else{
+            this.hass.callService("media_player", "volume_mute", {
+                entity_id: this._current_audio_device.entity_id,
+                is_volume_muted: true
+            });
+
+        }
+
     }
 
     _button(button) {

--- a/lg-remote-control.js
+++ b/lg-remote-control.js
@@ -257,7 +257,7 @@ class LgRemoteControl extends LitElement {
         if(!('sound_output' in stateObj.attributes)){
             // tv is off
             if("none" in this._custom_sound_devices){
-                this._current_audio_device =  this.hass.states[this._custom_sound_devices["off"].entity];
+                this._current_audio_device =  this.hass.states[this._custom_sound_devices["none"].entity];
             }
             else {
                 this._current_audio_device = stateObj;

--- a/lg-remote-control.js
+++ b/lg-remote-control.js
@@ -256,7 +256,12 @@ class LgRemoteControl extends LitElement {
         console.log(stateObj.attributes.sound_output, this._custom_sound_devices);
         if(!('sound_output' in stateObj.attributes)){
             // tv is off
-            this._current_audio_device =  stateObj;
+            if("off" in this._custom_sound_devices){
+                this._current_audio_device =  this.hass.states[this._custom_sound_devices["off"].entity];
+            }
+            else {
+                this._current_audio_device = stateObj;
+            }
         }
         else if(stateObj.attributes.sound_output in this._custom_sound_devices){
             this._current_audio_device =  this.hass.states[this._custom_sound_devices[stateObj.attributes.sound_output].entity];
@@ -459,8 +464,8 @@ class LgRemoteControl extends LitElement {
                 entity_id: this._current_audio_device.entity_id,
                 is_volume_muted: false
             });
-            //TODO: in the future: add config to choose if host should be muted as well for visual feedback
-            if(true){
+            //TODO: in the future: add config to choose if host should be muted as well for visual feedback.
+            if(false){
                 this.hass.callService("media_player", "volume_mute", {
                     entity_id: this.config.entity,
                     is_volume_muted: false
@@ -474,7 +479,7 @@ class LgRemoteControl extends LitElement {
                 is_volume_muted: true
             });
 
-            if(true){
+            if(false){
                 this.hass.callService("media_player", "volume_mute", {
                     entity_id: this.config.entity,
                     is_volume_muted: true

--- a/lg-remote-control.js
+++ b/lg-remote-control.js
@@ -256,7 +256,7 @@ class LgRemoteControl extends LitElement {
         console.log(stateObj.attributes.sound_output, this._custom_sound_devices);
         if(!('sound_output' in stateObj.attributes)){
             // tv is off
-            if("off" in this._custom_sound_devices){
+            if("none" in this._custom_sound_devices){
                 this._current_audio_device =  this.hass.states[this._custom_sound_devices["off"].entity];
             }
             else {

--- a/lg-remote-control.js
+++ b/lg-remote-control.js
@@ -253,7 +253,8 @@ class LgRemoteControl extends LitElement {
 
     render() {
         const stateObj = this.hass.states[this.config.entity];
-        console.log(stateObj.attributes.sound_output, this._custom_sound_devices);
+        //console.log(stateObj.attributes.sound_output, this._custom_sound_devices);
+
         if(!('sound_output' in stateObj.attributes)){
             // tv is off
             if("none" in this._custom_sound_devices){
@@ -269,7 +270,7 @@ class LgRemoteControl extends LitElement {
         }else{
             this._current_audio_device = stateObj;
         }
-        console.log("current audio device", this._current_audio_device.entity_id)
+        //console.log("current audio device", this._current_audio_device.entity_id)
 
 
         const colorButtons = this.config.color_buttons === "enable";
@@ -461,35 +462,45 @@ class LgRemoteControl extends LitElement {
     }
 
     _mute_toggle(){
+        let exec_active_set = function (mode){
+            this.hass.callService("media_player", "volume_mute", {
+                entity_id: this._current_audio_device.entity_id,
+                is_volume_muted: mode
+            });
+
+        }
+
+
         if(this._current_audio_device.attributes.is_volume_muted){
             //is now muted
 
-            if(true){
+            //TODO: in the future: add config to choose if host should be muted as well for visual feedback.
+            if(false){
+
                 this.hass.callService("media_player", "volume_mute", {
                     entity_id: this.config.entity,
                     is_volume_muted: false
                 });
+
+
+            }
+            else{
+                exec_active_set(false);
             }
 
-            this.hass.callService("media_player", "volume_mute", {
-                entity_id: this._current_audio_device.entity_id,
-                is_volume_muted: false
-            });
-            //TODO: in the future: add config to choose if host should be muted as well for visual feedback.
+
 
         }
         else{
-            if(true){
+            if(false){
                 this.hass.callService("media_player", "volume_mute", {
                     entity_id: this.config.entity,
                     is_volume_muted: true
                 });
+                sleep(500);
+            } else {
+                exec_active_set(true)
             }
-
-            this.hass.callService("media_player", "volume_mute", {
-                entity_id: this._current_audio_device.entity_id,
-                is_volume_muted: true
-            });
 
 
         }

--- a/lg-remote-control.js
+++ b/lg-remote-control.js
@@ -4,6 +4,7 @@
 var LitElement = LitElement || Object.getPrototypeOf(customElements.get("ha-panel-lovelace"));
 var html = LitElement.prototype.html;
 var css = LitElement.prototype.css;
+
 class LgRemoteControl extends LitElement {
 
     static get disneyIcon() {

--- a/lg-remote-control.js
+++ b/lg-remote-control.js
@@ -262,7 +262,7 @@ class LgRemoteControl extends LitElement {
         }else{
             const audioStateObj = stateObj;
         }
-
+        console.log("current audio device", audioStateObj.entity_id)
         const colorButtons = this.config.color_buttons === "enable";
 
         const borderWidth = this.config.dimensions && this.config.dimensions.border_width ? this.config.dimensions.border_width : "1px";

--- a/lg-remote-control.js
+++ b/lg-remote-control.js
@@ -252,7 +252,8 @@ class LgRemoteControl extends LitElement {
 
     render() {
         const stateObj = this.hass.states[this.config.entity];
-        console.log("HELLOOOO")
+        console.log(stateObj.attributes.sound_output, this._custom_sound_devices)
+
         if(this._custom_sound_devices.includes(stateObj.attributes.sound_output)){
 
             const audioStateObj = this._custom_sound_devices[stateObj.attributes.sound_output].entity;

--- a/lg-remote-control.js
+++ b/lg-remote-control.js
@@ -1,7 +1,7 @@
 import logging
 
 
-_LOGGER = logging.getLogger(__name__)
+var LOGGER = logging.getLogger(__name__)
 
 
 var LitElement = LitElement || Object.getPrototypeOf(customElements.get("ha-panel-lovelace"));
@@ -253,6 +253,7 @@ class LgRemoteControl extends LitElement {
     }
 
     render() {
+        LOGGER.warn("########  TESTETSTETET")
         const stateObj = this.hass.states[this.config.entity];
 
         if(stateObj.attributes.sound_output in this._custom_sound_devices){

--- a/lg-remote-control.js
+++ b/lg-remote-control.js
@@ -1,7 +1,4 @@
-import logging
 
-
-var LOGGER = logging.getLogger(__name__)
 
 
 var LitElement = LitElement || Object.getPrototypeOf(customElements.get("ha-panel-lovelace"));
@@ -253,9 +250,8 @@ class LgRemoteControl extends LitElement {
     }
 
     render() {
-        LOGGER.warn("########  TESTETSTETET")
         const stateObj = this.hass.states[this.config.entity];
-
+        console.log("HELLOOOO")
         if(stateObj.attributes.sound_output in this._custom_sound_devices){
 
             const audioStateObj = this._custom_sound_devices[stateObj.attributes.sound_output].entity;

--- a/lg-remote-control.js
+++ b/lg-remote-control.js
@@ -269,6 +269,8 @@ class LgRemoteControl extends LitElement {
             this._current_audio_device = stateObj;
         }
         console.log("current audio device", this._current_audio_device.entity_id)
+
+
         const colorButtons = this.config.color_buttons === "enable";
 
         const borderWidth = this.config.dimensions && this.config.dimensions.border_width ? this.config.dimensions.border_width : "1px";
@@ -460,32 +462,35 @@ class LgRemoteControl extends LitElement {
     _mute_toggle(){
         if(this._current_audio_device.attributes.is_volume_muted){
             //is now muted
+
+            if(true){
+                this.hass.callService("media_player", "volume_mute", {
+                    entity_id: this.config.entity,
+                    is_volume_muted: false
+                });
+            }
+
             this.hass.callService("media_player", "volume_mute", {
                 entity_id: this._current_audio_device.entity_id,
                 is_volume_muted: false
             });
             //TODO: in the future: add config to choose if host should be muted as well for visual feedback.
-            if(false){
-                this.hass.callService("media_player", "volume_mute", {
-                    entity_id: this.config.entity,
-                    is_volume_muted: false
-                });
 
-            }
         }
         else{
+            if(true){
+                this.hass.callService("media_player", "volume_mute", {
+                    entity_id: this.config.entity,
+                    is_volume_muted: true
+                });
+            }
+
             this.hass.callService("media_player", "volume_mute", {
                 entity_id: this._current_audio_device.entity_id,
                 is_volume_muted: true
             });
 
-            if(false){
-                this.hass.callService("media_player", "volume_mute", {
-                    entity_id: this.config.entity,
-                    is_volume_muted: true
-                });
 
-            }
         }
 
     }
@@ -534,8 +539,8 @@ class LgRemoteControl extends LitElement {
             console.log("Invalid configuration");
         }
         this.config = config;
-        if("custom_sound_devices" in this.config){
-            this._custom_sound_devices = this.config.custom_sound_devices;
+        if("sound_devices" in this.config){
+            this._custom_sound_devices = this.config.sound_devices;
         }
     }
 

--- a/lg-remote-control.js
+++ b/lg-remote-control.js
@@ -251,14 +251,13 @@ class LgRemoteControl extends LitElement {
     }
 
     render() {
-
         const stateObj = this.hass.states[this.config.entity];
         console.log(stateObj.attributes.sound_output, this._custom_sound_devices);
-        if(!stateObj.attributes.includes("sound_output")){
+        if(!('sound_output' in stateObj.attributes)){
             // tv is off
             const audioStateObj = stateObj;
         }
-        else if(this._custom_sound_devices.includes(stateObj.attributes.sound_output)){
+        else if(stateObj.attributes.sound_output in this._custom_sound_devices){
             const audioStateObj = this._custom_sound_devices[stateObj.attributes.sound_output].entity;
         }else{
             const audioStateObj = stateObj;

--- a/lg-remote-control.js
+++ b/lg-remote-control.js
@@ -258,6 +258,7 @@ class LgRemoteControl extends LitElement {
             // tv is off
             if("none" in this._custom_sound_devices){
                 this._current_audio_device =  this.hass.states[this._custom_sound_devices["none"].entity];
+
             }
             else {
                 this._current_audio_device = stateObj;

--- a/lg-remote-control.js
+++ b/lg-remote-control.js
@@ -462,14 +462,6 @@ class LgRemoteControl extends LitElement {
     }
 
     _mute_toggle(){
-        let exec_active_set = function (mode){
-            this.hass.callService("media_player", "volume_mute", {
-                entity_id: this._current_audio_device.entity_id,
-                is_volume_muted: mode
-            });
-
-        }
-
 
         if(this._current_audio_device.attributes.is_volume_muted){
             //is now muted
@@ -485,7 +477,10 @@ class LgRemoteControl extends LitElement {
 
             }
             else{
-                exec_active_set(false);
+                this.hass.callService("media_player", "volume_mute", {
+                    entity_id: this._current_audio_device.entity_id,
+                    is_volume_muted: false
+                });
             }
 
 
@@ -499,7 +494,10 @@ class LgRemoteControl extends LitElement {
                 });
                 sleep(500);
             } else {
-                exec_active_set(true)
+                this.hass.callService("media_player", "volume_mute", {
+                    entity_id: this._current_audio_device.entity_id,
+                    is_volume_muted: true
+                });
             }
 
 

--- a/lg-remote-control.js
+++ b/lg-remote-control.js
@@ -407,8 +407,8 @@ class LgRemoteControl extends LitElement {
                       <button class="btn ripple"  style="border-radius: 50% 50% 0px 0px; margin: 0px auto 0px auto; height: 100%;" @click=${() => this._media_player_entity_service("volume_up", this._current_audio_device.entity_id)}><ha-icon icon="mdi:plus"/></button>
                       <button class="btn-flat flat-high ripple" style="margin-top: 0px; height: 50%;" @click=${() => this._button("HOME")}><ha-icon icon="mdi:home"></button>
                       <button class="btn ripple" style="border-radius: 50% 50% 0px 0px; margin: 0px auto 0px auto; height: 100%;" @click=${() => this._button("CHANNELUP")}><ha-icon icon="mdi:chevron-up"/></button>
-                      <button class="btn" style="border-radius: 0px; cursor: default; margin: 0px auto 0px auto; height: 100%;"><ha-icon icon="${stateObj.attributes.is_volume_muted === true ? 'mdi:volume-off' : 'mdi:volume-high'}"/></button>
-                      <button class="btn ripple" Style="color:${stateObj.attributes.is_volume_muted === true ? 'red' : ''}; height: 100%;"" @click=${() => this._mute_toggle() /*this._button("MUTE")*/}><span class="${stateObj.attributes.is_volume_muted === true ? 'blink' : ''}"><ha-icon icon="mdi:volume-mute"></span></button>
+                      <button class="btn" style="border-radius: 0px; cursor: default; margin: 0px auto 0px auto; height: 100%;"><ha-icon icon="${this._current_audio_device.attributes.is_volume_muted === true ? 'mdi:volume-off' : 'mdi:volume-high'}"/></button>
+                      <button class="btn ripple" Style="color:${stateObj.attributes.is_volume_muted === true ? 'red' : ''}; height: 100%;"" @click=${() => this._mute_toggle() /*this._button("MUTE")*/}><span class="${this._current_audio_device.attributes.is_volume_muted === true ? 'blink' : ''}"><ha-icon icon="mdi:volume-mute"></span></button>
                       <button class="btn" style="border-radius: 0px; cursor: default; margin: 0px auto 0px auto; height: 100%;"><ha-icon icon="mdi:parking"/></button>
                       <button class="btn ripple" style="border-radius: 0px 0px 50% 50%;  margin: 0px auto 0px auto; height: 100%;" @click=${() => this._media_player_entity_service("volume_down", this._current_audio_device.entity_id)}><ha-icon icon="mdi:minus"/></button>
                       <button class="btn-flat flat-high ripple" style="margin-bottom: 0px; height: 50%;" @click=${() => this._button("INFO")}><ha-icon icon="mdi:information-variant"/></button>
@@ -459,6 +459,14 @@ class LgRemoteControl extends LitElement {
                 entity_id: this._current_audio_device.entity_id,
                 is_volume_muted: false
             });
+            //TODO: in the future: add config to choose if host should be muted as well for visual feedback
+            if(true){
+                this.hass.callService("media_player", "volume_mute", {
+                    entity_id: this.config.entity,
+                    is_volume_muted: false
+                });
+
+            }
         }
         else{
             this.hass.callService("media_player", "volume_mute", {
@@ -466,6 +474,13 @@ class LgRemoteControl extends LitElement {
                 is_volume_muted: true
             });
 
+            if(true){
+                this.hass.callService("media_player", "volume_mute", {
+                    entity_id: this.config.entity,
+                    is_volume_muted: true
+                });
+
+            }
         }
 
     }

--- a/lg-remote-control.js
+++ b/lg-remote-control.js
@@ -259,7 +259,7 @@ class LgRemoteControl extends LitElement {
             this._current_audio_device =  stateObj;
         }
         else if(stateObj.attributes.sound_output in this._custom_sound_devices){
-            this._current_audio_device =  this._custom_sound_devices[stateObj.attributes.sound_output].entity;
+            this._current_audio_device =  this.hass.states[this._custom_sound_devices[stateObj.attributes.sound_output].entity];
         }else{
             this._current_audio_device = stateObj;
         }

--- a/lg-remote-control.js
+++ b/lg-remote-control.js
@@ -569,7 +569,7 @@ class LgRemoteControl extends LitElement {
                     console.warn("Recording is not supported on custom media devices")
                     return;
             }
-            this._media_player_entity_service("media_player.media_"+service, this._current_media_device.entity_id)
+            this._media_player_entity_service("media_"+service, this._current_media_device.entity_id)
 
 
         }

--- a/lg-remote-control.js
+++ b/lg-remote-control.js
@@ -1,7 +1,12 @@
+import logging
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
 var LitElement = LitElement || Object.getPrototypeOf(customElements.get("ha-panel-lovelace"));
 var html = LitElement.prototype.html;
 var css = LitElement.prototype.css;
-
 class LgRemoteControl extends LitElement {
 
     static get disneyIcon() {
@@ -229,10 +234,12 @@ class LgRemoteControl extends LitElement {
         return {
             hass: {},
             config: {},
+            _custom_sound_devices: {},
             _show_inputs: {},
             _show_sound_output: {},
             _show_text: {},
             _show_keypad: {}
+
         };
     }
 
@@ -242,11 +249,19 @@ class LgRemoteControl extends LitElement {
         this._show_sound_output = false;
         this._show_text = false;
         this._show_keypad = false;
+        this._custom_sound_devices = {};
     }
 
     render() {
         const stateObj = this.hass.states[this.config.entity];
-        const audioStateObj = stateObj;
+
+        if(stateObj.attributes.sound_output in this._custom_sound_devices){
+
+            const audioStateObj = this._custom_sound_devices[stateObj.attributes.sound_output].entity;
+
+        }else{
+            const audioStateObj = stateObj;
+        }
 
         const colorButtons = this.config.color_buttons === "enable";
 
@@ -480,6 +495,9 @@ class LgRemoteControl extends LitElement {
             console.log("Invalid configuration");
         }
         this.config = config;
+        if("custom_sound_devices" in this.config){
+            this._custom_sound_devices = this.config._custom_sound_devices;
+        }
     }
 
     getCardSize() {

--- a/lg-remote-control.js
+++ b/lg-remote-control.js
@@ -540,7 +540,8 @@ class LgRemoteControl extends LitElement {
         }
         this.config = config;
         if("sound_devices" in this.config){
-            this._custom_sound_devices = this.config.sound_devices;
+            this.config.sound_devices.forEach(el => { this._custom_sound_devices[el.mode] = el})
+            //this._custom_sound_devices = this.config.sound_devices;
         }
     }
 

--- a/lg-remote-control.js
+++ b/lg-remote-control.js
@@ -540,7 +540,7 @@ class LgRemoteControl extends LitElement {
         }
         this.config = config;
         if("sound_devices" in this.config){
-            this.config.sound_devices.forEach(el => { this._custom_sound_devices[el.mode] = el})
+            this.config.sound_devices.forEach(el => { this._custom_sound_devices[el.name] = el})
             //this._custom_sound_devices = this.config.sound_devices;
         }
     }

--- a/lg-remote-control.js
+++ b/lg-remote-control.js
@@ -253,7 +253,7 @@ class LgRemoteControl extends LitElement {
     render() {
 
         const stateObj = this.hass.states[this.config.entity];
-        console.log(stateObj.attributes.sound_output, this._custom_sound_devices)
+        console.log(stateObj.attributes.sound_output, this._custom_sound_devices);
 
         if(this._custom_sound_devices.includes(stateObj.attributes.sound_output)){
 

--- a/lg-remote-control.js
+++ b/lg-remote-control.js
@@ -248,6 +248,7 @@ class LgRemoteControl extends LitElement {
         this._show_text = false;
         this._show_keypad = false;
         this._custom_sound_devices = {};
+        this._current_audio_device = undefined;
     }
 
     render() {
@@ -255,12 +256,12 @@ class LgRemoteControl extends LitElement {
         console.log(stateObj.attributes.sound_output, this._custom_sound_devices);
         if(!('sound_output' in stateObj.attributes)){
             // tv is off
-            const audioStateObj = stateObj;
+            this._current_audio_device =  stateObj;
         }
         else if(stateObj.attributes.sound_output in this._custom_sound_devices){
-            const audioStateObj = this._custom_sound_devices[stateObj.attributes.sound_output].entity;
+            this._current_audio_device =  this._custom_sound_devices[stateObj.attributes.sound_output].entity;
         }else{
-            const audioStateObj = stateObj;
+            this._current_audio_device = stateObj;
         }
         console.log("current audio device", audioStateObj.entity_id)
         const colorButtons = this.config.color_buttons === "enable";
@@ -403,13 +404,13 @@ class LgRemoteControl extends LitElement {
 <!-- ################################# COLORED BUTTONS END ################################# -->
 
                   <div class="grid-container-volume-channel-control" >
-                      <button class="btn ripple"  style="border-radius: 50% 50% 0px 0px; margin: 0px auto 0px auto; height: 100%;" @click=${() => this._media_player_entity_service("volume_up", audioStateObj.entity_id)}><ha-icon icon="mdi:plus"/></button>
+                      <button class="btn ripple"  style="border-radius: 50% 50% 0px 0px; margin: 0px auto 0px auto; height: 100%;" @click=${() => this._media_player_entity_service("volume_up", this._current_audio_device.entity_id)}><ha-icon icon="mdi:plus"/></button>
                       <button class="btn-flat flat-high ripple" style="margin-top: 0px; height: 50%;" @click=${() => this._button("HOME")}><ha-icon icon="mdi:home"></button>
                       <button class="btn ripple" style="border-radius: 50% 50% 0px 0px; margin: 0px auto 0px auto; height: 100%;" @click=${() => this._button("CHANNELUP")}><ha-icon icon="mdi:chevron-up"/></button>
                       <button class="btn" style="border-radius: 0px; cursor: default; margin: 0px auto 0px auto; height: 100%;"><ha-icon icon="${stateObj.attributes.is_volume_muted === true ? 'mdi:volume-off' : 'mdi:volume-high'}"/></button>
                       <button class="btn ripple" Style="color:${stateObj.attributes.is_volume_muted === true ? 'red' : ''}; height: 100%;"" @click=${() => this._button("MUTE")}><span class="${stateObj.attributes.is_volume_muted === true ? 'blink' : ''}"><ha-icon icon="mdi:volume-mute"></span></button>
                       <button class="btn" style="border-radius: 0px; cursor: default; margin: 0px auto 0px auto; height: 100%;"><ha-icon icon="mdi:parking"/></button>
-                      <button class="btn ripple" style="border-radius: 0px 0px 50% 50%;  margin: 0px auto 0px auto; height: 100%;" @click=${() => this._media_player_entity_service("volume_down", audioStateObj.entity_id)}><ha-icon icon="mdi:minus"/></button>
+                      <button class="btn ripple" style="border-radius: 0px 0px 50% 50%;  margin: 0px auto 0px auto; height: 100%;" @click=${() => this._media_player_entity_service("volume_down", this._current_audio_device.entity_id)}><ha-icon icon="mdi:minus"/></button>
                       <button class="btn-flat flat-high ripple" style="margin-bottom: 0px; height: 50%;" @click=${() => this._button("INFO")}><ha-icon icon="mdi:information-variant"/></button>
                       <button class="btn ripple" style="border-radius: 0px 0px 50% 50%;  margin: 0px auto 0px auto; height: 100%;"  @click=${() => this._button("CHANNELDOWN")}><ha-icon icon="mdi:chevron-down"/></button>
                   </div>

--- a/lg-remote-control.js
+++ b/lg-remote-control.js
@@ -263,7 +263,7 @@ class LgRemoteControl extends LitElement {
         }else{
             this._current_audio_device = stateObj;
         }
-        console.log("current audio device", audioStateObj.entity_id)
+        console.log("current audio device", this._current_audio_device.entity_id)
         const colorButtons = this.config.color_buttons === "enable";
 
         const borderWidth = this.config.dimensions && this.config.dimensions.border_width ? this.config.dimensions.border_width : "1px";


### PR DESCRIPTION
Hi all,

I experienced some problems while trying to change the volume of my soundbar (sonos playbar with optical cable to the TV). When configured correctly the playbar does change volume when using the physical remote, but i discovered that this behaviour is achieved by a little hack: when changing the volume the tv sends a command (RF) to the remote, and the remote transmits the IR command to the sonos bar. 

This causes two problems. The first one is pretty clear: when changing the volume from the web remote control card while the physical remote is hiding in the couch or god knows where, the IR-command never reaches the sonos bar. Secondly a situation can arise where the TV 'thinks' it is muted whilst the sonos is unmuted. Since the TV does not stop outputting sound to the optical output when muted, this causes a mute icon when the sonos is unmuted and visa versa. 

This pull request adds the possibility to add a custom media_player to control when a certain sound mode is selected or the device if off (control soundbar playing music when the tv is off). 

Check the readme for details! Im planning to write a option to also control the host so the mute icon is displayed when the host is muted, but since the host sometimes unmutes the output device (when the remote is pointed at the soundbar) and the tv does not specify mute on/off but just toggles it this was a little more work then expected.

- Closes #32 