### PR TITLE
Define custom Media control devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ channels:
 
 ### Media device Options
 
-If you have an external media that outputs the sound and the volume up/down/mute buttons are not passed to this device (HDMI CEC is sometimes a little hard for TV's..) you can define another media player to control. You can also specify an entity that should be controlled when the TV is in the off state.
+If you have an external media player and the media controls are not passed to this device (HDMI CEC is sometimes a little hard for TV's..) you can define a media_player to control directly using the media_player service. You can also specify an entity that should be controlled when the TV is in the off state.
 
 | Name | Type | Default | Supported options | Description |
 | -------------- | ----------- | ------------ | ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -120,6 +120,23 @@ channels:
     number: '503'
 ```
 
+### Media device Options
+
+If you have an external media that outputs the sound and the volume up/down/mute buttons are not passed to this device (HDMI CEC is sometimes a little hard for TV's..) you can define another media player to control. You can also specify an entity that should be controlled when the TV is in the off state.
+
+| Name | Type | Default | Supported options | Description |
+| -------------- | ----------- | ------------ | ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name` | string | **Required** | Source options: all sources listed for your device  and "none" for off-state | The name of the output mode this setting applies to |
+| `entity` | string | **Required** | entity_id | Entity of the media_player that should be controlled |
+```yaml
+
+media_devices:
+  - name: none
+    entity: media_player.sonos_bar
+  - name: HDMI1
+    entity: media_player.living_room_chromecast
+```
+
 ### Colors Options
 | Name | Type | Default | Supported options | Description |
 | -------------- | ----------- | ------------ | ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/lg-remote-control.js
+++ b/lg-remote-control.js
@@ -252,7 +252,7 @@ class LgRemoteControl extends LitElement {
 
         if(!('source' in stateObj.attributes)){
             // tv is off
-            if("none" in this._custom_media_control){
+            if("none" in this._custom_media_devices){
                 this._current_media_device =  this.hass.states[this._custom_media_devices["none"].entity];
             }
             else {

--- a/lg-remote-control.js
+++ b/lg-remote-control.js
@@ -487,7 +487,7 @@ class LgRemoteControl extends LitElement {
                     console.warn("Recording is not supported on custom media devices")
                     return;
             }
-            this._media_player_entity_service("media_player.media_"+service, this._current_media_device.entity_id)
+            this._media_player_entity_service("media_"+service, this._current_media_device.entity_id)
 
 
         }


### PR DESCRIPTION
Similar to #81, this gives the user the possibility to define custom devices to control depending on the TV state. You can now directly choose the device to send the play/pause/stop/next/prev buttons to.

 For example, my chromecast does not want to be controlled by my LG tv (god knows why). I have configured the remote so that when HDMI 1 is active the p/p/s buttons are routed to the chromecast instead of the TV.

Also, i can now skip/pause songs on the sonos when the tv is off (for me this increases the PartnerAcceptenceFactor) 