### PR TITLE
Prime Video icon key `amazon` mapping

### DIFF
--- a/lg-remote-control.js
+++ b/lg-remote-control.js
@@ -267,7 +267,8 @@ class LgRemoteControl extends LitElement {
         return {
             "disney": this.disneyIcon,
             "dazn": this.daznIcon,
-            "nowtv": this.nowTv
+            "nowtv": this.nowTv,
+            "amazon": this.amazon,
         };
     }
 


### PR DESCRIPTION
It was listed in the documentation but not mapped in code.