### PR TITLE
Fix HACS Install issue

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,5 @@
 {
 "name": "LG WebOS Remote Control",
-"content_in_root": true,
 "filename": "lg-remote-control.js",
 "render_readme" : true
 }


### PR DESCRIPTION
I’ve noticed that when installing with HACS, the file name is not appended corrrectly in resources. Instead null is inserted.

I believe this is because you have specified the content in root parameter, but the content is in a sub-directory. I therefore propose removing this option to resolve the issue.