### PR TITLE
Set box-sizing to border-box to prevent spilling over container

### DIFF
--- a/src/lg-remote-control.ts
+++ b/src/lg-remote-control.ts
@@ -131,7 +131,7 @@ class LgRemoteControl extends LitElement {
 
         return html`
             <div class="card">
-                <div class="page" style="--remote-button-color: ${buttonColor}; --remote-text-color: ${textColor}; --remote-color: ${backgroundColor}; --remotewidth: ${remoteWidth};  --main-border-color: ${borderColor}; --main-border-width: ${borderWidth}">
+                <div class="page" style="box-sizing: border-box; --remote-button-color: ${buttonColor}; --remote-text-color: ${textColor}; --remote-color: ${backgroundColor}; --remotewidth: ${remoteWidth};  --main-border-color: ${borderColor}; --main-border-width: ${borderWidth}">
                     ${this.config.name
                         ? html` <div class="tv_title" style="color:${tv_name_color}" >${this.config.name}</div> `
                         : ""}


### PR DESCRIPTION
When using this card within some containers (e.g. the new sections view), the remote spills outside of the card div, causing it to overlap with other content. This PR sets `box-sizing: border-box` so that the padding around the remote is included in it's space calculation, preventing this from happening

## Before

<img width="510" alt="Screenshot 2024-04-30 at 3 59 25 pm" src="https://github.com/madmicio/LG-WebOS-Remote-Control/assets/30210785/c7ab51bd-086e-4762-800e-4c6e38619a46">


## After

<img width="509" alt="Screenshot 2024-04-30 at 3 59 48 pm" src="https://github.com/madmicio/LG-WebOS-Remote-Control/assets/30210785/4cfd11d0-134e-446c-a3bc-5e4bc9fe8368">
